### PR TITLE
feature: update uuid

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 "use strict";
 
+import 'react-native-get-random-values'
+
 import {Platform, NativeModules} from "react-native";
 import packageJson from "./package.json";
 const {MixpanelReactNative} = NativeModules;

--- a/javascript/mixpanel-persistent.js
+++ b/javascript/mixpanel-persistent.js
@@ -10,7 +10,7 @@ import {
 } from "./mixpanel-constants";
 
 import {AsyncStorageAdapter} from "./mixpanel-storage";
-import uuid from "uuid";
+import {v4 as uuidv4} from "uuid";
 import {MixpanelLogger} from "mixpanel-react-native/javascript/mixpanel-logger";
 
 export class MixpanelPersistent {
@@ -59,7 +59,7 @@ export class MixpanelPersistent {
         this._identity[token].deviceId = deviceId;
       });
     if (!this._identity[token].deviceId) {
-      this._identity[token].deviceId = uuid.v4();
+      this._identity[token].deviceId = uuidv4();
       await this.storageAdapter.setItem(
         getDeviceIdKey(token),
         this._identity[token].deviceId

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "jest": "^26.6.3",
     "jest-fetch-mock": "^3.0.3",
     "metro-react-native-babel-preset": "^0.63.0",
-    "react-native": "^0.63.3",
-    "react-test-renderer": "16.13.1"
+    "react-test-renderer": "16.13.1",
+    "@react-native-async-storage/async-storage": "^1.21.0"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -59,7 +59,12 @@
     }
   },
   "dependencies": {
-    "@react-native-async-storage/async-storage": "^1.21.0",
-    "uuid": "3.3.2"
+    "react-native": "^0.63.3",
+    "uuid": "^9.0.1",
+    "react-native-get-random-values": "^1.11.0"
+  },
+  "peerDependencies": {
+    "react-native": "^0.63.3",
+    "react-native-get-random-values": "^1.11.0"
   }
 }


### PR DESCRIPTION
Fix for the warning during installation of the package:

"warning mixpanel-react-native > uuid@3.3.2: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details."